### PR TITLE
Aggiungi applicazione Streamlit per l'anonimizzazione con Presidio

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# Anonimizzatore di testi basato su Microsoft Presidio
+
+Applicazione web con interfaccia grafica (Streamlit) per l'anonimizzazione di testi tramite [Microsoft Presidio](https://github.com/microsoft/presidio). Permette di rilevare informazioni personali (PII) e di sostituirle in modo automatico con placeholder personalizzabili.
+
+## Funzionalità principali
+
+- Riconoscimento di entità sensibili tramite Presidio Analyzer.
+- Sostituzione personalizzata delle entità individuate (es. PERSON, EMAIL_ADDRESS, PHONE_NUMBER).
+- Supporto multi-lingua basato sui modelli spaCy disponibili (inglese e italiano, se installati).
+- Interfaccia grafica intuitiva per inserire testo, lanciare l'analisi e consultare i risultati.
+- Visualizzazione dettagliata delle entità riconosciute e delle sostituzioni effettuate.
+
+## Requisiti
+
+- Python 3.9 o superiore.
+- Dipendenze Python elencate in `requirements.txt`.
+- Modelli spaCy per le lingue da supportare (almeno `en_core_web_sm`).
+
+## Installazione
+
+1. Clona il repository e installa le dipendenze:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Installa i modelli spaCy necessari (almeno quello inglese):
+
+   ```bash
+   python -m spacy download en_core_web_sm
+   # facoltativo, per l'italiano
+   python -m spacy download it_core_news_sm
+   ```
+
+## Avvio dell'applicazione
+
+Esegui il server Streamlit indicando il file principale:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+L'interfaccia sarà disponibile all'indirizzo `http://localhost:8501`.
+
+## Utilizzo
+
+1. Incolla o digita il testo contenente informazioni sensibili.
+2. Seleziona la lingua corrispondente al testo.
+3. (Opzionale) Personalizza i placeholder per le diverse entità.
+4. Premi **Analizza e anonimizza** per avviare il processo.
+5. Consulta la tabella con le entità rilevate, il testo anonimizzato e i dettagli delle sostituzioni.
+
+I dati non vengono memorizzati permanentemente: i risultati restano disponibili solo durante la sessione corrente del browser.
+
+## Struttura del progetto
+
+- `streamlit_app.py`: interfaccia grafica e logica di orchestrazione.
+- `anonimizzatore/anonymizer.py`: wrapper riutilizzabile attorno agli engine di Presidio.
+- `requirements.txt`: elenco delle dipendenze necessarie per eseguire l'applicazione.
+
+## Sviluppo
+
+Per contribuire o estendere l'applicazione:
+
+- Aggiungi nuove entità personalizzate modificando `default_entity_replacements` in `anonymizer.py`.
+- Integra nuovi modelli spaCy aggiungendo la relativa voce al dizionario `_SPACY_MODELS`.
+- Esegui test statici con:
+
+  ```bash
+  python -m compileall anonimizzatore streamlit_app.py
+  ```
+
+## Licenza
+
+Questo progetto è rilasciato con licenza MIT.

--- a/anonimizzatore/__init__.py
+++ b/anonimizzatore/__init__.py
@@ -1,0 +1,5 @@
+"""Pacchetto principale per l'applicazione di anonimizzazione."""
+
+from .anonymizer import PresidioAnonymizer
+
+__all__ = ["PresidioAnonymizer"]

--- a/anonimizzatore/anonymizer.py
+++ b/anonimizzatore/anonymizer.py
@@ -1,0 +1,126 @@
+"""Utility di anonimizzazione basata su Microsoft Presidio."""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from presidio_analyzer import AnalyzerEngine, RecognizerRegistry, RecognizerResult
+from presidio_analyzer.nlp_engine import NlpEngineProvider
+from presidio_anonymizer import AnonymizerEngine
+
+# Mappa lingua -> modello spaCy raccomandato
+_SPACY_MODELS: Mapping[str, str] = {
+    "en": "en_core_web_sm",
+    "it": "it_core_news_sm",
+}
+
+
+def _is_spacy_model_available(model_name: str) -> bool:
+    """Restituisce True se il modello spaCy indicato è installato."""
+
+    return importlib.util.find_spec(model_name) is not None
+
+
+@dataclass
+class AnonymizationResult:
+    """Risultato dell'operazione di anonimizzazione."""
+
+    text: str
+    items: List[dict]
+
+
+class PresidioAnonymizer:
+    """Wrapper di alto livello attorno agli engine di Presidio."""
+
+    def __init__(self) -> None:
+        nlp_configuration = {"nlp_engine_name": "spacy", "models": []}
+        available_languages: List[str] = []
+
+        for language, model in _SPACY_MODELS.items():
+            if _is_spacy_model_available(model):
+                nlp_configuration["models"].append({"lang_code": language, "model_name": model})
+                available_languages.append(language)
+
+        if not nlp_configuration["models"]:
+            supported = ", ".join(f"{lang} ({model})" for lang, model in _SPACY_MODELS.items())
+            raise RuntimeError(
+                "Nessun modello spaCy disponibile. Installa almeno uno dei modelli richiesti, ad esempio con\\n"
+                f"  python -m spacy download en_core_web_sm\\n"
+                f"Modelli supportati: {supported}"
+            )
+
+        nlp_engine = NlpEngineProvider(nlp_configuration=nlp_configuration).create_engine()
+        registry = RecognizerRegistry()
+        registry.load_predefined_recognizers(nlp_engine=nlp_engine)
+
+        self._analyzer = AnalyzerEngine(nlp_engine=nlp_engine, registry=registry)
+        self._anonymizer = AnonymizerEngine()
+        self._languages = available_languages
+
+    @property
+    def languages(self) -> Sequence[str]:
+        """Lingue supportate dai modelli spaCy disponibili."""
+
+        return tuple(self._languages)
+
+    @staticmethod
+    def default_entity_replacements() -> Dict[str, str]:
+        """Restituisce una mappatura di default tra entità e valore sostitutivo."""
+
+        return {
+            "DEFAULT": "<ANONIMO>",
+            "PERSON": "<PERSONA>",
+            "LOCATION": "<LOCALITÀ>",
+            "EMAIL_ADDRESS": "<EMAIL>",
+            "PHONE_NUMBER": "<TELEFONO>",
+            "DATE_TIME": "<DATA>",
+            "IBAN_CODE": "<IBAN>",
+            "CREDIT_CARD": "<CARTA>",
+            "NRP": "<DOCUMENTO>",
+        }
+
+    def analyze_text(self, text: str, language: str) -> List[RecognizerResult]:
+        """Esegue l'analisi delle entità sensibili in *text* nella lingua indicata."""
+
+        if not text.strip():
+            return []
+
+        if language not in self._languages:
+            available = ", ".join(self._languages)
+            raise ValueError(f"Lingua '{language}' non supportata. Lingue disponibili: {available}")
+
+        return self._analyzer.analyze(text=text, language=language)
+
+    def anonymize_text(
+        self,
+        text: str,
+        recognizer_results: Iterable[RecognizerResult],
+        entity_replacements: Optional[Mapping[str, str]] = None,
+        default_value: Optional[str] = None,
+    ) -> AnonymizationResult:
+        """Anonimizza il testo originale usando i risultati di analisi forniti."""
+
+        replacements = dict(self.default_entity_replacements())
+        if entity_replacements:
+            replacements.update({k: v for k, v in entity_replacements.items() if v})
+        if default_value:
+            replacements["DEFAULT"] = default_value
+
+        operators: Dict[str, MutableMapping[str, str]] = {
+            entity: {"type": "replace", "new_value": value} for entity, value in replacements.items()
+        }
+
+        anonymized_result = self._anonymizer.anonymize(
+            text=text, analyzer_results=list(recognizer_results), operators=operators
+        )
+
+        items = [item.to_dict() for item in anonymized_result.items] if anonymized_result.items else []
+        return AnonymizationResult(text=anonymized_result.text, items=items)
+
+    @staticmethod
+    def serialize_recognizer_results(results: Iterable[RecognizerResult]) -> List[dict]:
+        """Serializza i risultati dell'analisi in un formato pronto per il frontend."""
+
+        return [result.to_dict() for result in results]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.32,<2
+presidio-analyzer>=2.2,<3
+presidio-anonymizer>=2.2,<3
+spacy>=3.5,<4
+pandas>=2.0,<3

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,124 @@
+"""Interfaccia Streamlit per l'anonimizzatore di testi basato su Presidio."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import streamlit as st
+
+from anonimizzatore import PresidioAnonymizer
+
+
+@st.cache_resource(show_spinner=True)
+def get_anonymizer() -> PresidioAnonymizer:
+    """Crea un'unica istanza condivisa di :class:`PresidioAnonymizer`."""
+
+    return PresidioAnonymizer()
+
+
+def _language_label(language_code: str) -> str:
+    labels: Dict[str, str] = {
+        "en": "Inglese",
+        "it": "Italiano",
+    }
+    return labels.get(language_code, language_code)
+
+
+def main() -> None:
+    st.set_page_config(page_title="Anonimizzatore Presidio", page_icon="🛡️", layout="wide")
+
+    st.title("Anonimizzatore di testo basato su Microsoft Presidio")
+    st.write(
+        "Questo strumento utilizza [Microsoft Presidio](https://github.com/microsoft/presidio) "
+        "per individuare e sostituire automaticamente informazioni sensibili presenti in un testo."
+    )
+
+    try:
+        anonymizer = get_anonymizer()
+    except RuntimeError as exc:
+        st.error(
+            "Impossibile inizializzare il motore di anonimizzazione. "
+            "Verifica di aver installato i modelli spaCy richiesti (ad esempio `en_core_web_sm`).\n\n"
+            f"Dettagli: {exc}"
+        )
+        st.stop()
+
+    if not anonymizer.languages:
+        st.warning("Nessun modello linguistico disponibile. Installa almeno un modello spaCy supportato.")
+        st.stop()
+
+    default_replacements = anonymizer.default_entity_replacements()
+
+    with st.form("anonymize_form", clear_on_submit=False):
+        text_to_process = st.text_area(
+            "Inserisci il testo da anonimizzare",
+            height=250,
+            placeholder="Scrivi o incolla qui il testo contenente dati sensibili...",
+        )
+        language = st.selectbox(
+            "Lingua del testo",
+            options=list(anonymizer.languages),
+            format_func=_language_label,
+        )
+
+        with st.expander("Personalizza sostituzioni", expanded=False):
+            default_value = st.text_input(
+                "Valore di sostituzione generico",
+                value=default_replacements.get("DEFAULT", "<ANONIMO>"),
+                help="Usato per tutte le entità che non dispongono di una personalizzazione specifica.",
+            )
+            custom_replacements: Dict[str, str] = {}
+            for entity, placeholder in default_replacements.items():
+                if entity == "DEFAULT":
+                    continue
+                custom_replacements[entity] = st.text_input(
+                    f"Sostituzione per {entity}",
+                    value=placeholder,
+                    key=f"replacement_{entity}",
+                )
+
+        submitted = st.form_submit_button("Analizza e anonimizza")
+
+    if submitted:
+        if not text_to_process.strip():
+            st.warning("Inserisci del testo prima di procedere.")
+            return
+
+        with st.spinner("Analisi del testo in corso..."):
+            recognizer_results = anonymizer.analyze_text(text=text_to_process, language=language)
+            anonymization = anonymizer.anonymize_text(
+                text=text_to_process,
+                recognizer_results=recognizer_results,
+                entity_replacements=custom_replacements,
+                default_value=default_value,
+            )
+
+        st.session_state["analysis_results"] = PresidioAnonymizer.serialize_recognizer_results(recognizer_results)
+        st.session_state["anonymized_text"] = anonymization.text
+        st.session_state["anonymized_items"] = anonymization.items
+
+    if "analysis_results" in st.session_state:
+        analysis_results = st.session_state.get("analysis_results", [])
+        anonymized_text = st.session_state.get("anonymized_text", "")
+        anonymized_items = st.session_state.get("anonymized_items", [])
+
+        st.subheader("Risultati dell'analisi")
+        if analysis_results:
+            st.dataframe(analysis_results, use_container_width=True)
+        else:
+            st.info("Nessuna entità sensibile rilevata nel testo fornito.")
+
+        st.subheader("Testo anonimizzato")
+        st.code(anonymized_text, language="markdown")
+
+        if anonymized_items:
+            st.subheader("Dettagli delle sostituzioni")
+            st.json(anonymized_items)
+
+        st.caption(
+            "I risultati sono memorizzati localmente nella sessione corrente per consentire confronti rapidi."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- crea un wrapper riutilizzabile su Microsoft Presidio per analisi e anonimizzazione dei testi
- realizza un'interfaccia grafica Streamlit con opzioni di personalizzazione dei placeholder
- documenta installazione, requisiti e modalità di avvio dell'applicazione

## Testing
- python -m compileall anonimizzatore streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cbcc8c44a0832ab56e48455ef92b7f